### PR TITLE
Fixing PieChartImagick.php problem

### DIFF
--- a/src/SamChristy/PieChart/PieChartImagick.php
+++ b/src/SamChristy/PieChart/PieChartImagick.php
@@ -2,6 +2,9 @@
 namespace SamChristy\PieChart;
 include 'PieChart.php';
 
+use Imagick;
+use ImagickDraw;
+
 /**
  * A lightweight class for drawing pie charts, using the ImageMagick library.
  * @author    Sam Christy <sam_christy@hotmail.co.uk>


### PR DESCRIPTION
Added "use" to class Imagick and ImagickDraw.

"Error: Class 'SamChristy\PieChart\Imagick'" in Symfony project.
